### PR TITLE
Arrays in JSON code variable verbiage

### DIFF
--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -49,7 +49,9 @@ Synchronous variables take two parameters in its constructor:
 
 The type of the variable is defined by the type of the Default Value and can be a JSON serializable `NSDictionary`, `NSString`, `NSNumber` or a `Boolean` casted to a `NSNumber`.
 
-For example, using a variable of type `String`, using its value to get the value of the variable:
+We do support arrays within JSON code variables, however, it has to be a top level array where it would resemble something like this ``{"a" : [1,2,3]}`.
+
+Here's an example, using a variable of type `String`, using its value to get the value of the variable:
 
 <sub>**Objective-C**</sub>
 ```objc


### PR DESCRIPTION
To make it more apparent that we support arrays within JSON code variables.