### PR TITLE
Ignored arm64 for pushing to cocoapods

### DIFF
--- a/Taplytics.podspec
+++ b/Taplytics.podspec
@@ -12,4 +12,5 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'Taplytics.framework'
   s.source_files = s.public_header_files = "Taplytics.framework/**/*.h"
   s.vendored_frameworks = "Taplytics.framework"
+  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end

--- a/Taplytics_tvOS.podspec
+++ b/Taplytics_tvOS.podspec
@@ -12,4 +12,5 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'Taplytics_tvOS.framework'
   s.source_files = s.public_header_files = "Taplytics_tvOS.framework/**/*.h"
   s.vendored_frameworks = "Taplytics_tvOS.framework"
+  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=appletvsimulator*]' => 'arm64' }
 end


### PR DESCRIPTION
## Summary

iOS 12 introduced arm64 simulator devices by default to `xcodebuild`; added an ignore line to the podspec.